### PR TITLE
feat: add IIM API client and virtual workspace support

### DIFF
--- a/docs/docs/iim-integration.md
+++ b/docs/docs/iim-integration.md
@@ -1,0 +1,108 @@
+---
+id: iim-integration
+title: IIM Platform Integration Overview
+sidebar_position: 1
+---
+
+This document captures the high-level plan for adapting Xplorer to operate against the Investigation Information Management (IIM) platform instead of the local filesystem. The effort is split into phased deliveries so that core functionality can be validated with investigators early and the integration risk can be contained.
+
+## Phase 1 – Foundation & API Integration (2–3 weeks)
+
+### Project setup
+- Fork Xplorer and establish the development environment (Node, Yarn, Tauri runtime).
+- Configure the desktop build pipeline so that the integrated client can be packaged for Windows/macOS/Linux using Tauri.
+
+### API abstraction layer
+- Introduce an `IIMApiClient` that mirrors the contracts from `IIM.Shared` and replaces direct filesystem access with REST calls.
+- Surface a mock implementation to unblock UI development before the C# backend is available.
+- Integrate the client inside `DirectoryAPI` so that paths beginning with `workspace://` are automatically routed to the virtual workspace service.
+
+### Authentication
+- Authenticate with username/password to receive short-lived API tokens and refresh tokens.
+- Cache tokens securely (OS credential vault on desktop) and ensure silent refresh five minutes before expiration.
+- Provide login/logout UI that reuses the existing Xplorer shell.
+
+### Workspace/file access
+- List available workspaces, hydrate the workspace sidebar, and navigate the virtual folder structure.
+- Support file upload through the initiate/confirm transaction pattern, and expose downloads through short-lived pre-signed URLs.
+- Present meaningful error states for API failures and offline mode.
+
+**Deliverable:** the Xplorer fork can authenticate, enumerate workspaces, browse files, and upload/download evidence using the IIM API.
+
+## Phase 2 – Virtual Folder Structure (2 weeks)
+
+### Workspace navigation
+- Replace the traditional filesystem tree with the workspace hierarchy (`workspace://{workspaceId}/…`).
+- Add a workspace switcher, recently accessed workspaces, and dedicated sections such as Primary Evidence, Quarantine, and Derived Exports.
+- Implement virtual folders backed by API data while maintaining Xplorer’s interaction model (breadcrumbs, multi-tab browsing, favorites).
+
+### Metadata-rich views
+- Extend the properties panel with tags, sensitivity, quarantine status, hash information, deduplication links, and chain-of-custody timelines.
+- Allow authorized users to edit metadata and surface status indicators through badges, colors, and icons.
+
+### Search
+- Replace the filesystem search with the API-backed search endpoint.
+- Expose advanced filters (tags, sensitivity, file types, date ranges, hash values, case numbers, OCR content) and support saved searches and history.
+
+**Deliverable:** complete virtual folder navigation with rich metadata rendering and advanced search.
+
+## Phase 3 – Investigation Workflow (2 weeks)
+
+### Bulk operations and relationships
+- Provide batch tagging, sensitivity changes, and workspace moves (e.g., Quarantine → Primary Evidence).
+- Visualize file relationships, parent/child containers, processed derivatives, and duplicate clusters.
+
+### Quarantine workflow
+- Implement a quarantine review queue with approve/reject actions, comments, and optional dual-control approvals.
+- Display quarantine health via dashboards and visual markers in the file list.
+
+### Tag management & pipeline visibility
+- Allow hierarchical tag creation, suggestions from analysis, and bulk tag operations.
+- Surface real-time pipeline state (SignalR/WebSockets) for ingestion, analysis completion, hash computation, and retry controls.
+
+**Deliverable:** fully supported investigation workflows with quarantine management, tagging, and live pipeline telemetry.
+
+## Phase 4 – Collaboration & Administration (2 weeks)
+
+### Workspace collaboration
+- Invite/assign users to workspaces with Owner/Member/Viewer roles.
+- Track activity (recent changes, active investigators) and deliver notifications for relevant updates.
+
+### Comments and annotations
+- Enable file-level discussions, threaded comments, @mentions, and moderation controls.
+
+### Administration
+- Provide system health dashboards (storage usage, queue backlog, error rates) and user/license management.
+- Offer an audit log browser with granular filtering.
+
+**Deliverable:** collaboration tooling, admin dashboards, and full user management capabilities.
+
+## Phase 5 – Advanced Features & Polish (1–2 weeks)
+
+### Visualization and analytics
+- Timeline, relationship, and geographic visualizations based on evidence metadata.
+- File type analytics, charts, and case-level insights.
+
+### Reporting & export
+- Build investigation packages (files + metadata) for court submission, including chain-of-custody reports and standard formats (ZIP, E01, etc.).
+- Provide a custom report builder and evidence summary generator.
+
+### Performance & cross-platform
+- Optimize for large datasets with lazy loading and infinite scroll.
+- Add keyboard shortcuts, drag & drop refinements, context menu customization, and dark/light themes.
+- Validate across Windows/macOS/Linux and outline an offline capability strategy.
+
+**Deliverable:** production-ready experience with advanced visualization, reporting, and performance improvements.
+
+## Technical considerations
+
+- **State management:** reuse Xplorer storage for UI preferences while caching workspace context and metadata securely. Plan for offline caching of frequently accessed evidence.
+- **Error handling:** degrade gracefully during API outages, surface investigator-friendly messages, and add retry logic for transient failures.
+- **Security:** enforce role-based UI controls, short-lived pre-signed URLs, and audit logging for every action.
+- **Success metrics:**
+  - Phase 1 – authentication and workspace browsing in the integrated client.
+  - Phase 2 – navigation of virtual folders with metadata.
+  - Phase 3 – evidence workflow operations.
+  - Phase 4 – collaboration capabilities.
+  - Phase 5 – performance, reporting, and platform coverage.
+- **Risk mitigation:** decouple the API client for easier backend changes, implement pagination/lazy loading early, continuously test on all target OSes, and retain familiar Xplorer UX patterns to drive adoption.

--- a/src/Service/directory.ts
+++ b/src/Service/directory.ts
@@ -2,41 +2,65 @@ import joinPath from '../Components/Functions/path/joinPath';
 import normalizeSlash from '../Components/Functions/path/normalizeSlash';
 import type FileMetaData from '../Typings/fileMetaData';
 import type { UnlistenFn } from '@tauri-apps/api/event';
-import { LnkData } from '../Typings/fileMetaData';
 import isTauri from '../Util/is-tauri';
 import { CHECK_EXIST_ENDPOINT, CHECK_ISDIR_ENDPOINT, GET_DIR_SIZE_ENDPOINT, READ_DIR_ENDPOINT } from '../Util/constants';
+import type { DirectoryData } from './types/directory';
+import {
+        getVirtualWorkspaceService,
+        isVirtualPath as isVirtualWorkspacePath,
+        setVirtualWorkspaceService,
+        VirtualWorkspaceService,
+} from './iim/virtualFileSystem';
 let listener: UnlistenFn;
 let searchListener: UnlistenFn;
-interface DirectoryData {
-	files: FileMetaData[];
-	number_of_files: number;
-	skipped_files: string[];
-	lnk_files: LnkData[];
-}
 /**
  * Invoke Rust command to read information of a directory
  */
 class DirectoryAPI {
-	readonly dirName: string;
-	readonly parentDir: string;
-	files: FileMetaData[];
-	constructor(dirName: string, parentDir?: string) {
-		if (parentDir) {
-			this.parentDir = normalizeSlash(parentDir);
-			this.dirName = normalizeSlash(joinPath(parentDir, dirName));
-		} else this.dirName = normalizeSlash(dirName);
-	}
-	/**
-	 * Get files inside a directory
-	 * @returns {Promise<DirectoryData>}
-	 */
-	getFiles(): Promise<DirectoryData> {
-		return new Promise((resolve, reject) => {
-			if (isTauri) {
-				const { invoke } = require('@tauri-apps/api');
-				invoke('read_directory', { dir: this.dirName })
-					.then((files: DirectoryData) => {
-						this.files = files.files;
+        readonly dirName: string;
+        readonly parentDir: string;
+        files: FileMetaData[];
+        private static virtualService: VirtualWorkspaceService | null = null;
+        constructor(dirName: string, parentDir?: string) {
+                if (parentDir) {
+                        this.parentDir = normalizeSlash(parentDir);
+                        this.dirName = normalizeSlash(joinPath(parentDir, dirName));
+                } else this.dirName = normalizeSlash(dirName);
+        }
+        static configureVirtualWorkspace(service: VirtualWorkspaceService): void {
+                setVirtualWorkspaceService(service);
+                DirectoryAPI.virtualService = service;
+        }
+        private static getVirtualService(): VirtualWorkspaceService {
+                if (!DirectoryAPI.virtualService) {
+                        DirectoryAPI.virtualService = getVirtualWorkspaceService();
+                }
+                return DirectoryAPI.virtualService;
+        }
+        private get isVirtual(): boolean {
+                return isVirtualWorkspacePath(this.dirName);
+        }
+        /**
+         * Get files inside a directory
+         * @returns {Promise<DirectoryData>}
+         */
+        getFiles(): Promise<DirectoryData> {
+                return new Promise((resolve, reject) => {
+                        if (this.isVirtual) {
+                                DirectoryAPI.getVirtualService()
+                                        .listDirectory(this.dirName)
+                                        .then((data) => {
+                                                this.files = data.files;
+                                                resolve(data);
+                                        })
+                                        .catch((error) => reject(error));
+                                return;
+                        }
+                        if (isTauri) {
+                                const { invoke } = require('@tauri-apps/api');
+                                invoke('read_directory', { dir: this.dirName })
+                                        .then((files: DirectoryData) => {
+                                                this.files = files.files;
 						resolve(files);
 					})
 					.catch((err: string) => {
@@ -60,13 +84,16 @@ class DirectoryAPI {
 	 * Check if given path is directory
 	 * @returns {Promise<boolean>}
 	 */
-	async isDir(): Promise<boolean> {
-		return new Promise((resolve) => {
-			if (isTauri) {
-				const { invoke } = require('@tauri-apps/api');
-				invoke('is_dir', { path: this.dirName }).then((result: boolean) => resolve(result));
-			} else {
-				fetch(CHECK_ISDIR_ENDPOINT + this.dirName, { method: 'GET' })
+        async isDir(): Promise<boolean> {
+                if (this.isVirtual) {
+                        return DirectoryAPI.getVirtualService().isDirectory(this.dirName);
+                }
+                return new Promise((resolve) => {
+                        if (isTauri) {
+                                const { invoke } = require('@tauri-apps/api');
+                                invoke('is_dir', { path: this.dirName }).then((result: boolean) => resolve(result));
+                        } else {
+                                fetch(CHECK_ISDIR_ENDPOINT + this.dirName, { method: 'GET' })
 					.then((response) => response.json())
 					.then((result: boolean) => resolve(result));
 			}
@@ -76,12 +103,15 @@ class DirectoryAPI {
 	 * Return true if folder exist
 	 * @returns {boolean}
 	 */
-	async exists(): Promise<boolean> {
-		if (isTauri) {
-			const { invoke } = require('@tauri-apps/api');
-			return await invoke('file_exist', { filePath: this.dirName });
-		} else {
-			const exists = await (await fetch(CHECK_EXIST_ENDPOINT + this.dirName, { method: 'GET' })).json();
+        async exists(): Promise<boolean> {
+                if (this.isVirtual) {
+                        return DirectoryAPI.getVirtualService().pathExists(this.dirName);
+                }
+                if (isTauri) {
+                        const { invoke } = require('@tauri-apps/api');
+                        return await invoke('file_exist', { filePath: this.dirName });
+                } else {
+                        const exists = await (await fetch(CHECK_EXIST_ENDPOINT + this.dirName, { method: 'GET' })).json();
 			return exists;
 		}
 	}
@@ -89,12 +119,16 @@ class DirectoryAPI {
 	 * Create dir if not exists
 	 * @returns {any}
 	 */
-	async mkdir(): Promise<boolean> {
-		if (isTauri) {
-			const { invoke } = require('@tauri-apps/api');
-			return await invoke('create_dir_recursive', {
-				dirPath: this.dirName,
-			});
+        async mkdir(): Promise<boolean> {
+                if (this.isVirtual) {
+                        console.warn('mkdir is not supported for virtual workspaces yet');
+                        return false;
+                }
+                if (isTauri) {
+                        const { invoke } = require('@tauri-apps/api');
+                        return await invoke('create_dir_recursive', {
+                                dirPath: this.dirName,
+                        });
 		}
 	}
 
@@ -103,12 +137,16 @@ class DirectoryAPI {
 	 * @param {() => void} cb - callback
 	 * @returns {any}
 	 */
-	async listen(cb: () => void): Promise<void> {
-		if (isTauri) {
-			const { invoke } = require('@tauri-apps/api');
-			invoke('listen_dir', { dir: this.dirName });
-			const { getCurrent } = require('@tauri-apps/api/window');
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async listen(cb: () => void): Promise<void> {
+                if (this.isVirtual) {
+                        console.warn('Directory change listeners are not supported for virtual workspaces yet');
+                        return;
+                }
+                if (isTauri) {
+                        const { invoke } = require('@tauri-apps/api');
+                        invoke('listen_dir', { dir: this.dirName });
+                        const { getCurrent } = require('@tauri-apps/api/window');
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
 			listener = await getCurrent().listen('changes', (e: any) => {
 				console.log(e);
 				cb();
@@ -119,23 +157,29 @@ class DirectoryAPI {
 	 * Unlisten to previous listener
 	 * @returns {Promise<void>}
 	 */
-	async unlisten(): Promise<void> {
-		if (isTauri) {
-			const { getCurrent } = require('@tauri-apps/api/window');
-			listener?.();
-			return getCurrent().emit('unlisten_dir');
-		}
+        async unlisten(): Promise<void> {
+                if (this.isVirtual) {
+                        return;
+                }
+                if (isTauri) {
+                        const { getCurrent } = require('@tauri-apps/api/window');
+                        listener?.();
+                        return getCurrent().emit('unlisten_dir');
+                }
 	}
 
 	/**
 	 * Get size of a directory
 	 * @returns {Promise<number>}
 	 */
-	async getSize(): Promise<number> {
-		if (isTauri) {
-			const { invoke } = require('@tauri-apps/api');
-			return await invoke('get_dir_size', { dir: this.dirName });
-		} else {
+        async getSize(): Promise<number> {
+                if (this.isVirtual) {
+                        return DirectoryAPI.getVirtualService().getSize(this.dirName);
+                }
+                if (isTauri) {
+                        const { invoke } = require('@tauri-apps/api');
+                        return await invoke('get_dir_size', { dir: this.dirName });
+                } else {
 			const size = await (await fetch(GET_DIR_SIZE_ENDPOINT + this.dirName, { method: 'GET' })).json();
 			return size;
 		}
@@ -145,12 +189,15 @@ class DirectoryAPI {
 	 * Stop all searching progress
 	 * @returns {Promise<boolean>}
 	 */
-	async stopSearching(): Promise<boolean> {
-		if (isTauri) {
-			const { getCurrent } = require('@tauri-apps/api/window');
+        async stopSearching(): Promise<boolean> {
+                if (this.isVirtual) {
+                        return false;
+                }
+                if (isTauri) {
+                        const { getCurrent } = require('@tauri-apps/api/window');
 
-			const listenerExist = searchListener !== null && searchListener !== undefined;
-			searchListener?.();
+                        const listenerExist = searchListener !== null && searchListener !== undefined;
+                        searchListener?.();
 			await getCurrent().emit('unsearch');
 			return listenerExist;
 		}
@@ -162,12 +209,18 @@ class DirectoryAPI {
 	 * @param {FileMetaData[] => void} callback - progress callback
 	 * @returns {any}
 	 */
-	async search(pattern: string, callback: (partialFound: FileMetaData[]) => void): Promise<FileMetaData[]> {
-		if (isTauri) {
-			const { getCurrent } = require('@tauri-apps/api/window');
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			searchListener = await getCurrent().listen('search_partial_result', (res: any) => {
-				if (searchListener !== null && searchListener !== undefined) callback(res.payload as FileMetaData[]);
+        async search(pattern: string, callback: (partialFound: FileMetaData[]) => void): Promise<FileMetaData[]> {
+                if (this.isVirtual) {
+                        const service = DirectoryAPI.getVirtualService();
+                        const results = await service.search(this.dirName, pattern);
+                        callback(results);
+                        return results;
+                }
+                if (isTauri) {
+                        const { getCurrent } = require('@tauri-apps/api/window');
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        searchListener = await getCurrent().listen('search_partial_result', (res: any) => {
+                                if (searchListener !== null && searchListener !== undefined) callback(res.payload as FileMetaData[]);
 			});
 			const { invoke } = require('@tauri-apps/api');
 			const res = await invoke('search_in_dir', { dirPath: this.dirName, pattern });

--- a/src/Service/iim/apiClient.ts
+++ b/src/Service/iim/apiClient.ts
@@ -1,0 +1,358 @@
+import {
+        AuthResult,
+        BulkOperation,
+        BulkOperationResult,
+        CreateWorkspaceRequest,
+        IIMApiClientOptions,
+        InitiateFileUploadResponse,
+        SearchQuery,
+        SearchResult,
+        UploadRequest,
+        UploadResponse,
+        VirtualFile,
+        Workspace,
+        WorkspaceUser,
+} from './types';
+import MockApiService from './mockService';
+import { resolveIntegrationConfig } from './config';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+interface RequestOptions {
+        body?: unknown;
+        retry?: boolean;
+}
+
+class IIMApiClient {
+        private baseUrl: string;
+        private token: string | null = null;
+        private refreshToken: string | null = null;
+        private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
+        private readonly isMockMode: boolean;
+        private readonly mockService: MockApiService;
+
+        constructor(options?: Partial<IIMApiClientOptions>) {
+                const config = resolveIntegrationConfig(options);
+                this.baseUrl = config.baseUrl.replace(/\/$/, '');
+                this.isMockMode = Boolean(config.mockMode);
+                this.mockService = new MockApiService();
+        }
+
+        async authenticate(username: string, password: string): Promise<AuthResult> {
+                if (this.isMockMode) {
+                        const result = await this.mockService.authenticate(username, password);
+                        this.applyAuthResult(result);
+                        return result;
+                }
+
+                const response = await this.post<AuthResult>('/api/auth/login', { username, password });
+                this.applyAuthResult(response);
+                return response;
+        }
+
+        async refreshAuthToken(): Promise<string> {
+                if (!this.refreshToken) {
+                        throw new Error('No refresh token available');
+                }
+
+                if (this.isMockMode) {
+                        const token = await this.mockService.refreshToken();
+                        this.token = token;
+                        return token;
+                }
+
+                const response = await this.post<AuthResult>('/api/auth/refresh', {
+                        refreshToken: this.refreshToken,
+                });
+                this.applyAuthResult(response);
+                return response.token;
+        }
+
+        async logout(): Promise<void> {
+                if (this.isMockMode) {
+                        await this.mockService.logout();
+                } else {
+                        await this.post('/api/auth/logout', {});
+                }
+                this.token = null;
+                this.refreshToken = null;
+                this.clearRefreshTimeout();
+        }
+
+        async getWorkspacesAsync(): Promise<Workspace[]> {
+                        if (this.isMockMode) {
+                                return this.mockService.getWorkspaces();
+                        }
+                        return this.get<Workspace[]>('/api/workspaces');
+        }
+
+        async getWorkspaceAsync(workspaceId: string): Promise<Workspace | null> {
+                if (this.isMockMode) {
+                        return this.mockService.getWorkspace(workspaceId);
+                }
+                return this.get<Workspace | null>(`/api/workspaces/${workspaceId}`);
+        }
+
+        async createWorkspace(request: CreateWorkspaceRequest): Promise<Workspace> {
+                if (this.isMockMode) {
+                        return this.mockService.createWorkspace(request);
+                }
+                return this.post<Workspace>('/api/workspaces', request);
+        }
+
+        async getFilesAsync(workspaceId: string): Promise<VirtualFile[]> {
+                if (this.isMockMode) {
+                        return this.mockService.getFiles(workspaceId);
+                }
+                return this.get<VirtualFile[]>(`/api/workspaces/${workspaceId}/files`);
+        }
+
+        async getFileAsync(fileId: string): Promise<VirtualFile | null> {
+                if (this.isMockMode) {
+                        return this.mockService.getFile(fileId);
+                }
+                return this.get<VirtualFile | null>(`/api/files/${fileId}`);
+        }
+
+        async initiateFileUploadAsync(
+                workspaceId: string,
+                path: string,
+                fileName: string,
+                fileSize: number,
+                fileHash: string
+        ): Promise<InitiateFileUploadResponse> {
+                if (this.isMockMode) {
+                        return this.mockService.initiateFileUpload(workspaceId, path, fileName, fileSize, fileHash);
+                }
+
+                return this.post<InitiateFileUploadResponse>('/api/files/initiate-upload', {
+                        workspaceId,
+                        path,
+                        fileName,
+                        fileSize,
+                        fileHash,
+                });
+        }
+
+        async confirmFileUploadAsync(transactionId: string): Promise<VirtualFile | null> {
+                if (this.isMockMode) {
+                        return this.mockService.confirmFileUpload(transactionId);
+                }
+
+                return this.post<VirtualFile | null>('/api/files/confirm-upload', { transactionId });
+        }
+
+        async uploadFileWithProgress(
+                request: UploadRequest,
+                formData: FormData,
+                onProgress?: (progress: number) => void
+        ): Promise<UploadResponse> {
+                if (this.isMockMode) {
+                        const response: UploadResponse = {
+                                uploadUrl: `https://mock-s3.amazonaws.com/upload/${Date.now()}`,
+                                bucket: 'mock-bucket',
+                                objectKey: `${request.workspaceId}/${request.fileName}`,
+                                expiresAt: new Date(Date.now() + 3600000),
+                        };
+                        return response;
+                }
+
+                return this.uploadWithProgress('/api/files/upload', formData, onProgress);
+        }
+
+        async searchFiles(workspaceId: string, query: SearchQuery): Promise<SearchResult> {
+                if (this.isMockMode) {
+                        return this.mockService.searchFiles(workspaceId, query);
+                }
+                return this.post<SearchResult>(`/api/workspaces/${workspaceId}/search`, query);
+        }
+
+        async downloadFile(fileId: string): Promise<string> {
+                if (this.isMockMode) {
+                        return this.mockService.downloadFile(fileId);
+                }
+                const response = await this.get<{ presignedUrl: string }>(`/api/files/${fileId}/download`);
+                return response.presignedUrl;
+        }
+
+        async getFilePreview(fileId: string): Promise<string> {
+                if (this.isMockMode) {
+                        return this.mockService.getFilePreview(fileId);
+                }
+                const response = await this.get<{ previewUrl: string }>(`/api/files/${fileId}/preview`);
+                return response.previewUrl;
+        }
+
+        async bulkOperation(operation: BulkOperation): Promise<BulkOperationResult> {
+                if (this.isMockMode) {
+                        return this.mockService.bulkOperation(operation);
+                }
+                return this.post<BulkOperationResult>('/api/files/bulk', operation);
+        }
+
+        async addTags(fileIds: string[], tags: string[]): Promise<void> {
+                if (this.isMockMode) {
+                        return this.mockService.addTags(fileIds, tags);
+                }
+                await this.post<void>('/api/files/tags/add', { fileIds, tags });
+        }
+
+        async removeTags(fileIds: string[], tags: string[]): Promise<void> {
+                if (this.isMockMode) {
+                        return this.mockService.removeTags(fileIds, tags);
+                }
+                await this.post<void>('/api/files/tags/remove', { fileIds, tags });
+        }
+
+        async getWorkspaceUsers(workspaceId: string): Promise<WorkspaceUser[]> {
+                if (this.isMockMode) {
+                        return this.mockService.getWorkspaceUsers(workspaceId);
+                }
+                return this.get<WorkspaceUser[]>(`/api/workspaces/${workspaceId}/users`);
+        }
+
+        async inviteUser(workspaceId: string, email: string, role: string): Promise<void> {
+                if (this.isMockMode) {
+                        return this.mockService.inviteUser(workspaceId, email, role);
+                }
+                await this.post<void>(`/api/workspaces/${workspaceId}/users/invite`, { email, role });
+        }
+
+        setTokens(token: string, refreshToken?: string, expiresAt?: Date): void {
+                this.token = token;
+                if (refreshToken) {
+                        this.refreshToken = refreshToken;
+                }
+                if (expiresAt) {
+                        this.scheduleTokenRefresh(expiresAt);
+                }
+        }
+
+        dispose(): void {
+                this.clearRefreshTimeout();
+        }
+
+        private applyAuthResult(result: AuthResult): void {
+                this.token = result.token;
+                this.refreshToken = result.refreshToken;
+                this.scheduleTokenRefresh(result.expiresAt);
+        }
+
+        private async get<T>(endpoint: string): Promise<T> {
+                return this.request<T>('GET', endpoint);
+        }
+
+        private async post<T>(endpoint: string, body: unknown): Promise<T> {
+                return this.request<T>('POST', endpoint, { body });
+        }
+
+        private async request<T>(method: HttpMethod, endpoint: string, options: RequestOptions = {}): Promise<T> {
+                if (this.isMockMode) {
+                        throw new Error('HTTP request should not be called in mock mode');
+                }
+
+                const response = await this.performRequest(method, endpoint, options.body);
+
+                if (response.status === 401 && !options.retry && this.refreshToken) {
+                        try {
+                                await this.refreshAuthToken();
+                                return this.request<T>(method, endpoint, { ...options, retry: true });
+                        } catch (error) {
+                                throw new Error('Authentication required');
+                        }
+                }
+
+                if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(`API Error: ${errorText}`);
+                }
+
+                if (response.status === 204) {
+                        return undefined as unknown as T;
+                }
+
+                return response.json() as Promise<T>;
+        }
+
+        private performRequest(method: HttpMethod, endpoint: string, body?: unknown): Promise<Response> {
+                const headers: Record<string, string> = {
+                        'Content-Type': 'application/json',
+                };
+
+                if (this.token) {
+                        headers['Authorization'] = `Bearer ${this.token}`;
+                }
+
+                const init: RequestInit = {
+                        method,
+                        headers,
+                };
+
+                if (body !== undefined) {
+                        init.body = JSON.stringify(body);
+                }
+
+                return fetch(`${this.baseUrl}${endpoint}`, init);
+        }
+
+        private uploadWithProgress(
+                endpoint: string,
+                formData: FormData,
+                onProgress?: (progress: number) => void
+        ): Promise<UploadResponse> {
+                return new Promise((resolve, reject) => {
+                        const xhr = new XMLHttpRequest();
+                        if (onProgress) {
+                                xhr.upload.addEventListener('progress', (event) => {
+                                        if (event.lengthComputable) {
+                                                const percentage = Math.round((event.loaded / event.total) * 100);
+                                                onProgress(percentage);
+                                        }
+                                });
+                        }
+
+                        xhr.addEventListener('load', () => {
+                                if (xhr.status >= 200 && xhr.status < 300) {
+                                        try {
+                                                const parsed: UploadResponse = JSON.parse(xhr.responseText);
+                                                resolve(parsed);
+                                        } catch (error) {
+                                                reject(error);
+                                        }
+                                } else {
+                                        reject(new Error(`Upload failed: ${xhr.statusText}`));
+                                }
+                        });
+
+                        xhr.addEventListener('error', () => reject(new Error('Upload failed')));
+
+                        xhr.open('POST', `${this.baseUrl}${endpoint}`);
+                        if (this.token) {
+                                xhr.setRequestHeader('Authorization', `Bearer ${this.token}`);
+                        }
+                        xhr.send(formData);
+                });
+        }
+
+        private scheduleTokenRefresh(expiresAt: Date): void {
+                this.clearRefreshTimeout();
+                const refreshTime = expiresAt.getTime() - Date.now() - 5 * 60 * 1000;
+                if (refreshTime > 0) {
+                        this.refreshTimeout = setTimeout(() => {
+                                this.refreshAuthToken().catch(() => {
+                                        this.token = null;
+                                        this.refreshToken = null;
+                                });
+                        }, refreshTime);
+                }
+        }
+
+        private clearRefreshTimeout(): void {
+                if (this.refreshTimeout) {
+                        clearTimeout(this.refreshTimeout);
+                        this.refreshTimeout = null;
+                }
+        }
+}
+
+export default IIMApiClient;

--- a/src/Service/iim/config.ts
+++ b/src/Service/iim/config.ts
@@ -1,0 +1,39 @@
+import type { IIMApiClientOptions } from './types';
+
+const DEFAULT_BASE_URL = ((): string => {
+        if (typeof window !== 'undefined') {
+                const globalBase = (window as unknown as { __IIM_API_BASE_URL__?: string }).__IIM_API_BASE_URL__;
+                if (globalBase) return globalBase;
+        }
+        if (typeof globalThis !== 'undefined') {
+                const globalBase = (globalThis as { __IIM_API_BASE_URL__?: string }).__IIM_API_BASE_URL__;
+                if (globalBase) return globalBase;
+        }
+        return 'https://api.iim.local';
+})();
+
+const DEFAULT_MOCK_MODE = ((): boolean => {
+        if (typeof window !== 'undefined') {
+                const flag = (window as unknown as { __IIM_API_MOCK_MODE__?: boolean }).__IIM_API_MOCK_MODE__;
+                if (typeof flag === 'boolean') return flag;
+        }
+        if (typeof globalThis !== 'undefined') {
+                const flag = (globalThis as { __IIM_API_MOCK_MODE__?: boolean }).__IIM_API_MOCK_MODE__;
+                if (typeof flag === 'boolean') return flag;
+        }
+        return true;
+})();
+
+export type IIMIntegrationConfig = IIMApiClientOptions;
+
+export const DEFAULT_IIM_INTEGRATION_CONFIG: IIMIntegrationConfig = {
+        baseUrl: DEFAULT_BASE_URL,
+        mockMode: DEFAULT_MOCK_MODE,
+};
+
+export const resolveIntegrationConfig = (
+        options?: Partial<IIMIntegrationConfig>
+): IIMIntegrationConfig => ({
+        ...DEFAULT_IIM_INTEGRATION_CONFIG,
+        ...options,
+});

--- a/src/Service/iim/mockService.ts
+++ b/src/Service/iim/mockService.ts
@@ -1,0 +1,441 @@
+import {
+        AuthResult,
+        BulkOperation,
+        BulkOperationResult,
+        CreateWorkspaceRequest,
+        InitiateFileUploadResponse,
+        SearchQuery,
+        SearchResult,
+        User,
+        VirtualFile,
+        Workspace,
+        WorkspaceUser,
+} from './types';
+
+interface UploadTransaction {
+        workspaceId: string;
+        path: string;
+        fileName: string;
+        fileSize: number;
+        fileHash: string;
+        status: 'pending' | 'confirmed';
+}
+
+class MockApiService {
+        private mockWorkspaces: Workspace[] = [];
+        private mockFiles: VirtualFile[] = [];
+        private mockUsers: User[] = [];
+        private mockTransactions: Map<string, UploadTransaction> = new Map();
+
+        constructor() {
+                this.initializeMockData();
+        }
+
+        async authenticate(_username: string, _password: string): Promise<AuthResult> {
+                await this.simulateDelay();
+                return {
+                        success: true,
+                        token: 'mock-jwt-token-' + Date.now(),
+                        refreshToken: 'mock-refresh-token-' + Date.now(),
+                        expiresAt: new Date(Date.now() + 3600000),
+                        user: this.mockUsers[0],
+                };
+        }
+
+        async refreshToken(): Promise<string> {
+                await this.simulateDelay(200);
+                return 'refreshed-token-' + Date.now();
+        }
+
+        async logout(): Promise<void> {
+                await this.simulateDelay(100);
+        }
+
+        async getWorkspaces(): Promise<Workspace[]> {
+                await this.simulateDelay();
+                return [...this.mockWorkspaces];
+        }
+
+        async getWorkspace(workspaceId: string): Promise<Workspace | null> {
+                await this.simulateDelay();
+                return this.mockWorkspaces.find((w) => w.id === workspaceId) || null;
+        }
+
+        async createWorkspace(request: CreateWorkspaceRequest): Promise<Workspace> {
+                await this.simulateDelay(800);
+                const newWorkspace: Workspace = {
+                        id: this.generateId(),
+                        name: request.name,
+                        description: request.description,
+                        type: request.type,
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        createdBy: request.ownerId || 'current-user',
+                        isDeleted: false,
+                        isPublic: false,
+                        users: [],
+                        files: [],
+                        sessions: [],
+                };
+                this.mockWorkspaces.push(newWorkspace);
+                return newWorkspace;
+        }
+
+        async getFiles(workspaceId: string): Promise<VirtualFile[]> {
+                await this.simulateDelay();
+                return this.mockFiles.filter((f) => f.workspaceId === workspaceId);
+        }
+
+        async getFile(fileId: string): Promise<VirtualFile | null> {
+                await this.simulateDelay();
+                return this.mockFiles.find((f) => f.id === fileId) || null;
+        }
+
+        async initiateFileUpload(
+                workspaceId: string,
+                path: string,
+                fileName: string,
+                fileSize: number,
+                fileHash: string
+        ): Promise<InitiateFileUploadResponse> {
+                await this.simulateDelay(300);
+
+                const existingFile = this.mockFiles.find((f) => f.storedFileHash === fileHash);
+                if (existingFile) {
+                        return {
+                                isDuplicate: true,
+                                virtualFile: existingFile,
+                        };
+                }
+
+                const transactionId = this.generateId();
+                this.mockTransactions.set(transactionId, {
+                        workspaceId,
+                        path,
+                        fileName,
+                        fileSize,
+                        fileHash,
+                        status: 'pending',
+                });
+
+                return {
+                        isDuplicate: false,
+                        transactionId,
+                        uploadUrl: `https://mock-s3.amazonaws.com/upload/${transactionId}`,
+                };
+        }
+
+        async confirmFileUpload(transactionId: string): Promise<VirtualFile | null> {
+                await this.simulateDelay(500);
+
+                const transaction = this.mockTransactions.get(transactionId);
+                if (!transaction) {
+                        throw new Error('Transaction not found');
+                }
+
+                const newFile: VirtualFile = {
+                        id: this.generateId(),
+                        workspaceId: transaction.workspaceId,
+                        fileName: transaction.fileName,
+                        path: transaction.path,
+                        fileSize: transaction.fileSize,
+                        status: 'uploaded',
+                        storedFileHash: transaction.fileHash,
+                        createdAt: new Date(),
+                        createdBy: 'current-user',
+                        collectedBy: 'current-user',
+                        collectionDate: new Date(),
+                        collectedLocation: 'Digital Upload',
+                        customMetadata: {},
+                        chainOfCustody: [
+                                {
+                                        action: 'File Uploaded',
+                                        actor: 'current-user',
+                                        timestamp: new Date(),
+                                        details: 'File uploaded via mock interface',
+                                },
+                        ],
+                        processedVersions: [],
+                        dataSensitivity: 'internal',
+                        tags: [],
+                        description: '',
+                };
+
+                this.mockFiles.push(newFile);
+                this.mockTransactions.delete(transactionId);
+
+                return newFile;
+        }
+
+        async searchFiles(workspaceId: string, query: SearchQuery): Promise<SearchResult> {
+                await this.simulateDelay(400);
+
+                let results = this.mockFiles.filter((f) => f.workspaceId === workspaceId);
+
+                if (query.query) {
+                        const searchTerm = query.query.toLowerCase();
+                        results = results.filter(
+                                (f) =>
+                                        f.fileName.toLowerCase().includes(searchTerm) ||
+                                        f.description.toLowerCase().includes(searchTerm)
+                        );
+                }
+
+                if (query.tags && query.tags.length > 0) {
+                        const tagSet = new Set(query.tags);
+                        results = results.filter((f) => {
+                                if (!f.tags || f.tags.length === 0) return false;
+                                return f.tags.some((tag) => tagSet.has(tag));
+                        });
+                }
+
+                if (query.dateRange) {
+                        const from = new Date(query.dateRange.from);
+                        const to = new Date(query.dateRange.to);
+                        results = results.filter((f) => {
+                                const createdAt = new Date(f.createdAt);
+                                return createdAt >= from && createdAt <= to;
+                        });
+                }
+
+                const sortKey = query.sortBy;
+                results.sort((a, b) => {
+                        const aVal = this.extractComparableValue(a, sortKey);
+                        const bVal = this.extractComparableValue(b, sortKey);
+                        if (aVal === bVal) return 0;
+                        if (query.sortDirection === 'desc') {
+                                return aVal > bVal ? -1 : 1;
+                        }
+                        return aVal > bVal ? 1 : -1;
+                });
+
+                const start = (query.page - 1) * query.pageSize;
+                const paginatedResults = results.slice(start, start + query.pageSize);
+
+                return {
+                        files: paginatedResults,
+                        totalCount: results.length,
+                        page: query.page,
+                        pageSize: query.pageSize,
+                };
+        }
+
+        async downloadFile(fileId: string): Promise<string> {
+                await this.simulateDelay(200);
+                return `https://mock-s3.amazonaws.com/download/${fileId}?expires=${Date.now() + 3600000}`;
+        }
+
+        async getFilePreview(fileId: string): Promise<string> {
+                await this.simulateDelay(300);
+                return `https://mock-s3.amazonaws.com/preview/${fileId}?expires=${Date.now() + 3600000}`;
+        }
+
+        async bulkOperation(operation: BulkOperation): Promise<BulkOperationResult> {
+                await this.simulateDelay(1000);
+
+                const failures = operation.fileIds.slice(0, Math.floor(operation.fileIds.length * 0.1));
+                const successes = operation.fileIds.filter((id) => !failures.includes(id));
+
+                return {
+                        success: failures.length === 0,
+                        processedCount: successes.length,
+                        failedCount: failures.length,
+                        errors: failures.map((fileId) => ({
+                                fileId,
+                                error: 'Mock error for testing',
+                        })),
+                };
+        }
+
+        async addTags(fileIds: string[], tags: string[]): Promise<void> {
+                await this.simulateDelay(500);
+                fileIds.forEach((fileId) => {
+                        const file = this.mockFiles.find((f) => f.id === fileId);
+                        if (file) {
+                                const existingTags = new Set([...(file.tags || []), ...tags]);
+                                file.tags = Array.from(existingTags);
+                        }
+                });
+        }
+
+        async removeTags(fileIds: string[], tags: string[]): Promise<void> {
+                await this.simulateDelay(500);
+                fileIds.forEach((fileId) => {
+                        const file = this.mockFiles.find((f) => f.id === fileId);
+                        if (file && file.tags) {
+                                file.tags = file.tags.filter((tag) => !tags.includes(tag));
+                        }
+                });
+        }
+
+        async getWorkspaceUsers(workspaceId: string): Promise<WorkspaceUser[]> {
+                await this.simulateDelay();
+                return [
+                        {
+                                id: this.generateId(),
+                                workspaceId,
+                                userId: 'user1',
+                                role: 'Owner',
+                        },
+                        {
+                                id: this.generateId(),
+                                workspaceId,
+                                userId: 'user2',
+                                role: 'Member',
+                        },
+                ];
+        }
+
+        async inviteUser(_workspaceId: string, _email: string, _role: string): Promise<void> {
+                await this.simulateDelay(800);
+        }
+
+        private extractComparableValue(file: VirtualFile, key: SearchQuery['sortBy']): number | string {
+                if (key === 'fileSize') return file.fileSize;
+                if (key === 'createdAt') return new Date(file.createdAt).getTime();
+                if (key === 'updatedAt') return new Date(file.updatedAt || file.createdAt).getTime();
+                return file.fileName.toLowerCase();
+        }
+
+        private generateId(): string {
+                return 'mock-' + Math.random().toString(36).substring(2, 11);
+        }
+
+        private async simulateDelay(ms = 500): Promise<void> {
+                await new Promise((resolve) => setTimeout(resolve, ms));
+        }
+
+        private initializeMockData(): void {
+                this.mockUsers = [
+                        {
+                                id: 'user1',
+                                username: 'det.smith',
+                                email: 'det.smith@agency.gov',
+                                role: 'investigator',
+                                permissions: ['read', 'write', 'investigate'],
+                                workspaces: ['ws1', 'ws2'],
+                        },
+                ];
+
+                this.mockWorkspaces = [
+                        {
+                                id: 'ws1',
+                                name: 'Case-2024-001: Data Breach Investigation',
+                                description: 'Investigation of suspected data breach at client company',
+                                type: 'investigation',
+                                createdAt: new Date('2024-01-15'),
+                                updatedAt: new Date(),
+                                createdBy: 'det.smith@agency.gov',
+                                isDeleted: false,
+                                isPublic: false,
+                                users: [],
+                                files: [],
+                                sessions: [],
+                        },
+                        {
+                                id: 'ws2',
+                                name: 'Case-2024-002: Financial Fraud',
+                                description: 'Investigation of financial fraud case',
+                                type: 'investigation',
+                                createdAt: new Date('2024-02-01'),
+                                updatedAt: new Date(),
+                                createdBy: 'det.smith@agency.gov',
+                                isDeleted: false,
+                                isPublic: false,
+                                users: [],
+                                files: [],
+                                sessions: [],
+                        },
+                ];
+
+                this.mockFiles = [
+                        {
+                                id: 'file1',
+                                workspaceId: 'ws1',
+                                fileName: 'suspect_laptop.E01',
+                                path: '/evidence/computers/suspect_laptop.E01',
+                                fileSize: 500 * 1024 * 1024 * 1024,
+                                status: 'complete',
+                                storedFileHash:
+                                        'a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456',
+                                createdAt: new Date('2024-01-16'),
+                                createdBy: 'forensic.tech@agency.gov',
+                                collectedBy: 'forensic.tech@agency.gov',
+                                collectionDate: new Date('2024-01-16'),
+                                collectedLocation: "Suspect's Office",
+                                customMetadata: {
+                                        'acquisition.tool': 'FTK Imager',
+                                        'acquisition.version': '4.7.1',
+                                        'device.make': 'Dell',
+                                        'device.model': 'Latitude 7420',
+                                },
+                                chainOfCustody: [
+                                        {
+                                                action: 'Evidence Collected',
+                                                actor: 'forensic.tech@agency.gov',
+                                                timestamp: new Date('2024-01-16T08:30:00Z'),
+                                                details: 'Device seized from suspect office under warrant #2024-001',
+                                        },
+                                        {
+                                                action: 'Disk Image Created',
+                                                actor: 'forensic.tech@agency.gov',
+                                                timestamp: new Date('2024-01-16T10:30:00Z'),
+                                                details: 'Full disk image created using FTK Imager v4.7.1',
+                                        },
+                                        {
+                                                action: 'Hash Verification',
+                                                actor: 'Automated System',
+                                                timestamp: new Date('2024-01-16T10:45:00Z'),
+                                                details:
+                                                        'SHA256 hash verified: a1b2c3d4e5f6789012345678901234567890abcdef',
+                                        },
+                                ],
+                                processedVersions: [],
+                                dataSensitivity: 'confidential',
+                                tags: ['computer-evidence', 'suspect-device', 'laptop', 'primary-evidence'],
+                                description:
+                                        'Primary suspect laptop containing potential evidence of data breach',
+                        },
+                        {
+                                id: 'file2',
+                                workspaceId: 'ws1',
+                                fileName: 'network_logs_2024-01.zip',
+                                path: '/evidence/network/network_logs_2024-01.zip',
+                                fileSize: 128 * 1024 * 1024,
+                                status: 'complete',
+                                storedFileHash:
+                                        'b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef12345678',
+                                createdAt: new Date('2024-01-17'),
+                                createdBy: 'network.admin@client.com',
+                                collectedBy: 'det.jones@agency.gov',
+                                collectionDate: new Date('2024-01-17'),
+                                collectedLocation: 'Client Network Operations Center',
+                                customMetadata: {
+                                        'source.system': 'Palo Alto Networks Firewall',
+                                        'date.range': '2024-01-01 to 2024-01-31',
+                                        'file.count': '2847',
+                                },
+                                chainOfCustody: [
+                                        {
+                                                action: 'Logs Requested',
+                                                actor: 'det.jones@agency.gov',
+                                                timestamp: new Date('2024-01-17T09:00:00Z'),
+                                                details: 'Network logs requested from client IT department',
+                                        },
+                                        {
+                                                action: 'Logs Provided',
+                                                actor: 'network.admin@client.com',
+                                                timestamp: new Date('2024-01-17T11:30:00Z'),
+                                                details: 'Network logs exported and provided on encrypted USB drive',
+                                        },
+                                ],
+                                processedVersions: [],
+                                dataSensitivity: 'internal',
+                                tags: ['network-logs', 'firewall', 'january-2024'],
+                                description: 'Network firewall logs for January 2024',
+                        },
+                ];
+        }
+}
+
+export default MockApiService;

--- a/src/Service/iim/types.ts
+++ b/src/Service/iim/types.ts
@@ -1,0 +1,203 @@
+export interface ChainOfCustodyEntry {
+        action: string;
+        actor: string;
+        timestamp: Date | string;
+        details: string;
+}
+
+export interface ProcessedFile {
+        id: string;
+        processType: string;
+        processedAt: Date | string;
+        processedBy: string;
+        outputPath: string;
+        metadata: Record<string, unknown>;
+}
+
+export interface VirtualFile {
+        id: string;
+        workspaceId: string;
+        fileName: string;
+        path: string;
+        fileSize: number;
+        status: 'pending' | 'uploading' | 'uploaded' | 'processing' | 'complete' | 'error';
+        storedFileHash: string;
+        createdAt: Date | string;
+        updatedAt?: Date | string;
+        createdBy: string;
+        collectedBy: string;
+        collectionDate: Date | string;
+        collectedLocation: string;
+        customMetadata: Record<string, string>;
+        chainOfCustody: ChainOfCustodyEntry[];
+        processedVersions: ProcessedFile[];
+        dataSensitivity: 'public' | 'internal' | 'confidential' | 'secret';
+        tags?: string[];
+        description: string;
+}
+
+export interface ClassificationTag {
+        id: string;
+        name: string;
+        category: string;
+        confidence: number;
+}
+
+export interface StoredFile {
+        hash: string;
+        fileSize: number;
+        mimeType: string;
+        classificationTags: ClassificationTag[];
+        virtualFiles: VirtualFile[];
+}
+
+export interface WorkspaceUser {
+        id: string;
+        workspaceId: string;
+        userId: string;
+        role: string;
+}
+
+export interface InvestigationSession {
+        id: string;
+        workspaceId: string;
+        name: string;
+        startedAt: Date | string;
+        endedAt?: Date | string;
+        status: string;
+}
+
+export interface Workspace {
+        id: string;
+        name: string;
+        description: string;
+        type: 'investigation' | 'training' | 'research';
+        createdAt: Date | string;
+        updatedAt: Date | string;
+        createdBy: string;
+        isDeleted: boolean;
+        isPublic: boolean;
+        users: WorkspaceUser[];
+        files: VirtualFile[];
+        sessions: InvestigationSession[];
+}
+
+export interface WorkspaceSummary {
+        id: string;
+        name: string;
+        type: string;
+        updatedAt: Date | string;
+        fileCount: number;
+        activeSessions: number;
+}
+
+export interface WorkspaceStatistics {
+        totalFiles: number;
+        totalFileSize: number;
+        totalSessions: number;
+        activeSessions: number;
+        totalReports: number;
+        totalFindings: number;
+        totalTime: string;
+        filesByType: Record<string, number>;
+        filesBySeverity: Record<string, number>;
+}
+
+export interface VirtualFolder {
+        name: string;
+        path: string;
+        files: VirtualFile[];
+        subFolders: VirtualFolder[];
+}
+
+export interface InitiateFileUploadResponse {
+        isDuplicate: boolean;
+        transactionId?: string;
+        uploadUrl?: string;
+        virtualFile?: VirtualFile;
+}
+
+export interface CreateWorkspaceRequest {
+        name: string;
+        description: string;
+        type: 'investigation' | 'training' | 'research';
+        ownerId?: string;
+}
+
+export interface SearchWorkspacesRequest {
+        query?: string;
+        page: number;
+        pageSize: number;
+}
+
+export interface UploadRequest {
+        workspaceId: string;
+        fileName: string;
+        requiresQuarantine: boolean;
+}
+
+export interface UploadResponse {
+        uploadUrl: string;
+        bucket: string;
+        objectKey: string;
+        expiresAt: Date | string;
+}
+
+export interface SearchQuery {
+        query?: string;
+        tags?: string[];
+        sensitivityLevels?: string[];
+        fileTypes?: string[];
+        uploadedBy?: string;
+        dateRange?: {
+                from: Date | string;
+                to: Date | string;
+        };
+        page: number;
+        pageSize: number;
+        sortBy: 'fileName' | 'fileSize' | 'createdAt' | 'updatedAt';
+        sortDirection: 'asc' | 'desc';
+}
+
+export interface SearchResult {
+        files: VirtualFile[];
+        totalCount: number;
+        page: number;
+        pageSize: number;
+}
+
+export interface BulkOperation {
+        operation: 'tag' | 'move' | 'delete' | 'setSensitivity';
+        fileIds: string[];
+        parameters: Record<string, unknown>;
+}
+
+export interface BulkOperationResult {
+        success: boolean;
+        processedCount: number;
+        failedCount: number;
+        errors: { fileId: string; error: string }[];
+}
+
+export interface AuthResult {
+        success: boolean;
+        token: string;
+        refreshToken: string;
+        expiresAt: Date;
+        user: User;
+        error?: string;
+}
+
+export interface User {
+        id: string;
+        username: string;
+        email: string;
+        role: 'admin' | 'investigator' | 'analyst' | 'viewer';
+        permissions: string[];
+        workspaces: string[];
+}
+
+export interface IIMApiClientOptions {
+        baseUrl: string;
+        mockMode?: boolean;
+}

--- a/src/Service/iim/virtualFileSystem.ts
+++ b/src/Service/iim/virtualFileSystem.ts
@@ -1,0 +1,364 @@
+import type FileMetaData from '../../Typings/fileMetaData';
+import type { DirectoryData } from '../types/directory';
+import IIMApiClient from './apiClient';
+import type {
+        AuthResult,
+        BulkOperation,
+        BulkOperationResult,
+        SearchQuery,
+        SearchResult,
+        VirtualFile,
+        Workspace,
+} from './types';
+import { resolveIntegrationConfig } from './config';
+
+const VIRTUAL_SCHEME = 'workspace://';
+
+interface NormalizedVirtualFile extends VirtualFile {
+        normalizedPath: string;
+        directoryPath: string;
+}
+
+interface WorkspaceCache {
+        workspace: Workspace | null;
+        files: Map<string, NormalizedVirtualFile>;
+        directories: Set<string>;
+}
+
+export interface VirtualPathInfo {
+        workspaceId: string;
+        relativePath: string;
+        isRoot: boolean;
+}
+
+export class VirtualWorkspaceService {
+        private readonly apiClient: IIMApiClient;
+        private readonly workspaceCache: Map<string, WorkspaceCache> = new Map();
+
+        constructor(apiClient?: IIMApiClient) {
+                this.apiClient = apiClient ?? new IIMApiClient(resolveIntegrationConfig());
+        }
+
+        get client(): IIMApiClient {
+                return this.apiClient;
+        }
+
+        isVirtualPath(path: string): boolean {
+                return path.startsWith(VIRTUAL_SCHEME);
+        }
+
+        parseVirtualPath(virtualPath: string): VirtualPathInfo {
+                if (!this.isVirtualPath(virtualPath)) {
+                        throw new Error(`Invalid virtual path: ${virtualPath}`);
+                }
+
+                const withoutScheme = virtualPath.slice(VIRTUAL_SCHEME.length);
+                const [workspaceId, ...rest] = withoutScheme.split('/');
+                if (!workspaceId) {
+                        throw new Error(`Virtual path missing workspace identifier: ${virtualPath}`);
+                }
+
+                const relativePath = this.normalizeFolderPath(rest.join('/'));
+                const isRoot = relativePath === '/';
+
+                return { workspaceId, relativePath, isRoot };
+        }
+
+        async listDirectory(virtualPath: string): Promise<DirectoryData> {
+                const info = this.parseVirtualPath(virtualPath);
+                const cache = await this.ensureWorkspaceCache(info.workspaceId);
+                const entries: FileMetaData[] = [];
+                const seenDirectories = new Set<string>();
+
+                cache.files.forEach((file) => {
+                        if (!this.isDescendant(file.normalizedPath, info.relativePath)) return;
+                        const relativePath = this.toRelativePath(file.normalizedPath, info.relativePath);
+                        if (!relativePath) return;
+                        const segments = relativePath.split('/').filter(Boolean);
+                        if (segments.length === 0) return;
+
+                        if (segments.length === 1) {
+                                entries.push(this.toFileMeta(info.workspaceId, file));
+                        } else {
+                                const directoryKey = this.joinPaths(info.relativePath, segments[0]);
+                                if (!seenDirectories.has(directoryKey)) {
+                                        entries.push(this.toDirectoryMeta(info.workspaceId, directoryKey, segments[0]));
+                                        seenDirectories.add(directoryKey);
+                                }
+                        }
+                });
+
+                cache.directories.forEach((directory) => {
+                        if (!this.isDescendant(directory, info.relativePath)) return;
+                        if (directory === info.relativePath) return;
+                        const relativePath = this.toRelativePath(directory, info.relativePath);
+                        if (!relativePath) return;
+                        const [segment] = relativePath.split('/').filter(Boolean);
+                        if (!segment) return;
+                        const directoryKey = this.joinPaths(info.relativePath, segment);
+                        if (!seenDirectories.has(directoryKey)) {
+                                entries.push(this.toDirectoryMeta(info.workspaceId, directoryKey, segment));
+                                seenDirectories.add(directoryKey);
+                        }
+                });
+
+                return {
+                        files: this.sortEntries(entries),
+                        number_of_files: entries.length,
+                        skipped_files: [],
+                        lnk_files: [],
+                };
+        }
+
+        async pathExists(virtualPath: string): Promise<boolean> {
+                const info = this.parseVirtualPath(virtualPath);
+                const cache = await this.ensureWorkspaceCache(info.workspaceId);
+
+                if (info.relativePath === '/') return true;
+
+                if (cache.files.has(info.relativePath)) return true;
+                if (cache.directories.has(info.relativePath)) return true;
+
+                return false;
+        }
+
+        async isDirectory(virtualPath: string): Promise<boolean> {
+                const info = this.parseVirtualPath(virtualPath);
+                if (info.relativePath === '/') return true;
+                const cache = await this.ensureWorkspaceCache(info.workspaceId);
+                if (cache.directories.has(info.relativePath)) return true;
+                if (cache.files.has(info.relativePath)) return false;
+                return false;
+        }
+
+        async getSize(virtualPath: string): Promise<number> {
+                const info = this.parseVirtualPath(virtualPath);
+                const cache = await this.ensureWorkspaceCache(info.workspaceId);
+
+                const matched = cache.files.get(info.relativePath);
+                if (matched) {
+                        return matched.fileSize;
+                }
+
+                let total = 0;
+                cache.files.forEach((file) => {
+                        if (this.isDescendant(file.normalizedPath, info.relativePath)) {
+                                total += file.fileSize;
+                        }
+                });
+                return total;
+        }
+
+        async search(virtualPath: string, pattern: string): Promise<FileMetaData[]> {
+                const info = this.parseVirtualPath(virtualPath);
+                const query: SearchQuery = {
+                        query: pattern,
+                        page: 1,
+                        pageSize: 200,
+                        sortBy: 'fileName',
+                        sortDirection: 'asc',
+                };
+                const result: SearchResult = await this.apiClient.searchFiles(info.workspaceId, query);
+                return result.files
+                        .map((file) => this.normalizeFile(file))
+                        .filter((file) =>
+                                info.relativePath === '/'
+                                        ? true
+                                        : this.isDescendant(file.normalizedPath, info.relativePath) ||
+                                          file.normalizedPath === info.relativePath
+                        )
+                        .map((file) => this.toFileMeta(info.workspaceId, file));
+        }
+
+        async bulkOperation(operation: BulkOperation): Promise<BulkOperationResult> {
+                return this.apiClient.bulkOperation(operation);
+        }
+
+        async authenticate(username: string, password: string): Promise<AuthResult> {
+                const result = await this.apiClient.authenticate(username, password);
+                this.workspaceCache.clear();
+                return result;
+        }
+
+        clearCache(): void {
+                this.workspaceCache.clear();
+        }
+
+        private async ensureWorkspaceCache(workspaceId: string): Promise<WorkspaceCache> {
+                const existing = this.workspaceCache.get(workspaceId);
+                if (existing) return existing;
+
+                const [workspace, files] = await Promise.all([
+                        this.apiClient.getWorkspaceAsync(workspaceId),
+                        this.apiClient.getFilesAsync(workspaceId),
+                ]);
+
+                const normalizedFiles = new Map<string, NormalizedVirtualFile>();
+                const directories = new Set<string>(['/']);
+
+                files.forEach((file) => {
+                        const normalized = this.normalizeFile(file);
+                        normalizedFiles.set(normalized.normalizedPath, normalized);
+                        this.collectDirectories(normalized.directoryPath, directories);
+                });
+
+                const cache: WorkspaceCache = {
+                        workspace: workspace ?? null,
+                        files: normalizedFiles,
+                        directories,
+                };
+
+                this.workspaceCache.set(workspaceId, cache);
+                return cache;
+        }
+
+        private normalizeFile(file: VirtualFile): NormalizedVirtualFile {
+                const normalizedPath = this.normalizeFilePath(file.path || file.fileName);
+                const directoryPath = this.getDirectoryPath(normalizedPath);
+
+                return {
+                        ...file,
+                        createdAt: new Date(file.createdAt),
+                        updatedAt: file.updatedAt ? new Date(file.updatedAt) : undefined,
+                        collectionDate: new Date(file.collectionDate),
+                        processedVersions: file.processedVersions?.map((processed) => ({
+                                ...processed,
+                                processedAt: new Date(processed.processedAt),
+                        })),
+                        chainOfCustody: file.chainOfCustody?.map((entry) => ({
+                                ...entry,
+                                timestamp: new Date(entry.timestamp),
+                        })),
+                        normalizedPath,
+                        directoryPath,
+                };
+        }
+
+        private collectDirectories(path: string, directories: Set<string>): void {
+                        if (!path) return;
+                        let current = path;
+                        while (current && !directories.has(current)) {
+                                directories.add(current);
+                                if (current === '/') break;
+                                current = this.getDirectoryPath(current);
+                        }
+        }
+
+        private normalizeFolderPath(path: string): string {
+                if (!path || path === '.') return '/';
+                const normalized = this.normalizeFilePath(path);
+                if (normalized === '') return '/';
+                return normalized;
+        }
+
+        private normalizeFilePath(path: string): string {
+                let normalized = path.replace(/\\/g, '/');
+                if (!normalized.startsWith('/')) {
+                        normalized = '/' + normalized;
+                }
+                normalized = normalized.replace(/\/+/g, '/');
+                if (normalized.length > 1 && normalized.endsWith('/')) {
+                        normalized = normalized.slice(0, -1);
+                }
+                return normalized;
+        }
+
+        private getDirectoryPath(path: string): string {
+                if (path === '/' || path === '') return '/';
+                const trimmed = path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
+                const index = trimmed.lastIndexOf('/');
+                if (index <= 0) return '/';
+                return trimmed.slice(0, index);
+        }
+
+        private joinPaths(base: string, segment: string): string {
+                if (base === '/') return `/${segment}`;
+                return `${base}/${segment}`;
+        }
+
+        private isDescendant(path: string, parent: string): boolean {
+                if (parent === '/') return path !== '';
+                if (path === parent) return false;
+                return path.startsWith(parent.endsWith('/') ? parent : `${parent}/`);
+        }
+
+        private toRelativePath(path: string, parent: string): string {
+                if (parent === '/') {
+                        return path.slice(1);
+                }
+                const prefix = parent.endsWith('/') ? parent : `${parent}/`;
+                if (!path.startsWith(prefix)) return '';
+                return path.slice(prefix.length);
+        }
+
+        private toFileMeta(workspaceId: string, file: NormalizedVirtualFile): FileMetaData {
+                return {
+                        file_path: `${VIRTUAL_SCHEME}${workspaceId}${file.normalizedPath}`,
+                        basename: file.fileName,
+                        file_type: this.getFileType(file.fileName),
+                        is_trash: false,
+                        is_dir: false,
+                        is_file: true,
+                        size: file.fileSize,
+                        last_modified: this.toSystemTime(file.updatedAt || file.createdAt),
+                        created: this.toSystemTime(file.createdAt),
+                };
+        }
+
+        private toDirectoryMeta(workspaceId: string, path: string, name: string): FileMetaData {
+                return {
+                        file_path: `${VIRTUAL_SCHEME}${workspaceId}${path}`,
+                        basename: name,
+                        file_type: 'Directory',
+                        is_trash: false,
+                        is_dir: true,
+                        is_file: false,
+                };
+        }
+
+        private sortEntries(entries: FileMetaData[]): FileMetaData[] {
+                return entries.sort((a, b) => {
+                        const aDir = Boolean(a.is_dir);
+                        const bDir = Boolean(b.is_dir);
+                        if (aDir && !bDir) return -1;
+                        if (!aDir && bDir) return 1;
+                        return a.basename.localeCompare(b.basename, undefined, { sensitivity: 'base' });
+                });
+        }
+
+        private getFileType(fileName: string): string {
+                const dotIndex = fileName.lastIndexOf('.');
+                if (dotIndex === -1 || dotIndex === fileName.length - 1) {
+                        return 'File';
+                }
+                return `${fileName.slice(dotIndex + 1).toUpperCase()} File`;
+        }
+
+        private toSystemTime(date: Date | undefined): FileMetaData['created'] {
+                if (!date) return undefined;
+                const time = date.getTime();
+                const seconds = Math.floor(time / 1000);
+                const nanos = (time - seconds * 1000) * 1e6;
+                return {
+                        secs_since_epoch: seconds,
+                        nanos_since_epoch: Math.round(nanos),
+                };
+        }
+}
+
+let defaultService: VirtualWorkspaceService | null = null;
+
+export const getVirtualWorkspaceService = (): VirtualWorkspaceService => {
+        if (!defaultService) {
+                defaultService = new VirtualWorkspaceService();
+        }
+        return defaultService;
+};
+
+export const setVirtualWorkspaceService = (service: VirtualWorkspaceService): void => {
+        defaultService = service;
+};
+
+export const isVirtualPath = (path: string): boolean => path.startsWith(VIRTUAL_SCHEME);
+
+export { VIRTUAL_SCHEME };

--- a/src/Service/types/directory.ts
+++ b/src/Service/types/directory.ts
@@ -1,0 +1,8 @@
+import type FileMetaData, { LnkData } from '../../Typings/fileMetaData';
+
+export interface DirectoryData {
+        files: FileMetaData[];
+        number_of_files: number;
+        skipped_files: string[];
+        lnk_files: LnkData[];
+}


### PR DESCRIPTION
## Summary
- add an IIM API client and mock backend to mirror the Investigation Information Management contracts
- route workspace:// paths in DirectoryAPI through a virtual workspace service that maps API responses to Xplorer metadata
- capture the phased IIM integration plan in the docs site for future implementation work

## Testing
- yarn lint *(fails: existing lint violations in src/Components/Files/File Operation/select.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5483b9b1083268550772bc20993ac