### PR TITLE
Fix chain of custody panel element lookup

### DIFF
--- a/src/Components/Metadata/MetadataPanel.ts
+++ b/src/Components/Metadata/MetadataPanel.ts
@@ -195,12 +195,16 @@ class MetadataPanel {
         `;
 	}
 
-	private updateChainOfCustody(file: VirtualFile): void {
-		const custodyEl = document.getElementById('chain-of-custody');
-		if (!custodyEl || !file.chainOfCustody?.length) {
-			custodyEl.innerHTML = '<p class="empty-state">No chain of custody information available</p>';
-			return;
-		}
+        private updateChainOfCustody(file: VirtualFile): void {
+                const custodyEl = this.panelElement?.querySelector('#chain-of-custody') as HTMLElement | null;
+                if (!custodyEl) {
+                        return;
+                }
+
+                if (!file.chainOfCustody?.length) {
+                        custodyEl.innerHTML = '<p class="empty-state">No chain of custody information available</p>';
+                        return;
+                }
 
 		const custodyHtml = file.chainOfCustody
 			.map(


### PR DESCRIPTION
## Summary
- guard the chain-of-custody update routine when the container element is missing
- scope the chain-of-custody lookup to the metadata panel instead of using the global document

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d81fba01288326bf042d89c88936b5